### PR TITLE
Add Performance & Scalability documentation section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -85,6 +85,15 @@
             ]
           }
         ]
+      },
+      {
+        "group": "Performance",
+        "pages": [
+          "pages/performance/introduction",
+          "pages/performance/ingestion-and-freshness",
+          "pages/performance/query-latency",
+          "pages/performance/scaling-best-practices"
+        ]
       }
     ]
   }

--- a/pages/performance/ingestion-and-freshness.mdx
+++ b/pages/performance/ingestion-and-freshness.mdx
@@ -1,0 +1,64 @@
+---
+title: "Ingestion Latency"
+---
+
+**Ingestion latency** is the platform metric that answers "how quickly does new data become available?" — once a value is ingested at the site, how long until you can read it through the API. This page measures it, and then explains why it should not be confused with **data freshness** — a related but distinct concept.
+
+---
+
+## Ingestion latency
+
+**Definition:** once a value is ingested at the site by the Nexalis Agent, how long until you can read it through the API (`/api/v0/exec`).
+
+**How it is measured.** The Nexalis Agent emits a heartbeat signal roughly every 10 seconds. That heartbeat travels in the **same message queue as regular data point messages**, so its arrival time is representative of all data. Each heartbeat arrival was detected with sub-second polling, and all timings use the Nexalis **server clock** — there is no client clock involved, so the numbers are free of client-side skew.
+
+### Results
+
+Measured across live sites (heartbeat cadence ~10 s):
+
+| Metric | Value |
+|--------|-------|
+| Fastest observed (best case, no batching wait) | **~0.5 s** |
+| **Median ingestion latency** (typical) | **~5 s** |
+| **95th percentile** (conservative planning figure) | **~7 s** |
+| Slowest observed in the campaign | **~9 s** |
+| Measurement precision (per-event window) | ~0.6 s |
+
+**Interpretation:**
+
+- The **median ~5 s** is the time you should expect from "value ingested at site" to "value readable via API" under normal conditions. It includes the Nexalis Agent's normal message-batching cycle.
+- The **best case ~0.5 s** occurs when a message leaves the Nexalis Agent immediately — it reflects pure transport, cloud ingestion, and indexing with no batching wait.
+- Use the **p95 (~7 s)** when sizing alerting or real-time control loops that depend on data availability.
+- Latency was stable across sites of different sizes — ingestion latency does **not** grow with the number of tags in your environment.
+
+<Note>
+Ingestion latency is independent of how you query. It is the lower bound on how fresh any read can possibly be: even a query that runs instantly cannot return a value sooner than it was ingested.
+</Note>
+
+---
+
+## Don't confuse latency with data freshness
+
+When a tag shows a value that is a few minutes old, people sometimes read that as a platform delay. It usually isn't. There are two distinct things at play:
+
+- **Ingestion latency** (above) — how long the *platform* takes to make a new value readable. Measured in **seconds**, and constant regardless of environment size.
+- **Data freshness** — how long ago each data point *actually changed*. This is set by **your process and signals**, not by Nexalis.
+
+Nexalis collects data by **trigger on value change** (report by exception): a data point only produces a new value when its measurement moves outside its deadband, or when the minimum ~1-value-per-hour heartbeat fires. So a data point that hasn't updated in minutes is almost always a **quiet signal** — a stable measurement, a value inside its deadband, or a slow-cadence tag — not a lost or delayed one.
+
+This is why freshness varies enormously and is **not a platform benchmark**: a busy site will show most tags updating within seconds, while a quieter environment will legitimately show many tags unchanged for minutes at a time. Both are behaving correctly.
+
+<Note>
+**Practical rule.** Ingestion latency is the lower bound on how fresh any read can possibly be — even an instant query cannot return a value sooner than it was ingested. Data freshness sits on top of that and reflects how often your signals move. When a value looks "old," check whether the underlying signal actually changed before suspecting the platform.
+</Note>
+
+---
+
+## Putting it together
+
+For a real-time use case — say, polling the latest values of all tags every 30 seconds — the data you read will be:
+
+- at most **~5–7 s** behind the site (ingestion latency), plus
+- however long since each signal last actually changed (freshness, driven by the signal type).
+
+Ingestion latency doesn't grow with the number of tags, so the same real-time responsiveness holds whether you consume one site or many. For the query side of that loop, see [Query Latency](./query-latency).

--- a/pages/performance/introduction.mdx
+++ b/pages/performance/introduction.mdx
@@ -1,0 +1,71 @@
+---
+title: "Performance & Scalability"
+---
+
+The Nexalis Platform is built to deliver industrial data with **low latency at scale**, end to end — from the **Nexalis Agent** ingesting values at the site to **Nexalis Cloud** serving that data through the API. This section documents how the platform performs in practice — how quickly data becomes available after it is ingested at the site, how fast the API answers read requests, and how performance evolves as an environment grows from a handful of tags to hundreds of thousands.
+
+All figures on the following pages come from **live measurement campaigns on production environments**, using the Nexalis Cloud API. Environment and customer names have been removed; the numbers and the behavior they describe are representative of what any consumer of the API experiences.
+
+---
+
+## What we measure
+
+Performance comes down to two platform metrics:
+
+| Metric | Question it answers | Page |
+|--------|--------------------|------|
+| **Ingestion latency** | Once a value is ingested at the site, how long until you can read it through the API? | [Ingestion Latency](./ingestion-and-freshness) |
+| **Query latency** | How long does an API read request take to return? | [Query Latency](./query-latency) |
+
+Cutting across both is **scaling behavior** — how these metrics change as data volume and time ranges grow, and how to query efficiently at scale. This is covered on the [Scaling & Best Practices](./scaling-best-practices) page.
+
+A related concept, **data freshness** — how recently each signal last changed — is often confused with latency but is a property of *your* signals, not the platform. It is explained (not benchmarked) on the [Ingestion Latency](./ingestion-and-freshness) page.
+
+<Note>
+Nexalis pushes data **on change** (report by exception) with a minimum heartbeat of roughly one value per hour per signal. A tag that hasn't updated recently is usually a quiet signal — a value inside its deadband or a slow-cadence measurement — not a platform delay. Keep this in mind when a tag's latest value looks older than you expect.
+</Note>
+
+---
+
+## Headline numbers
+
+For a typical consumer:
+
+- **Ingestion latency** — a value is readable through the API a **median of ~5 seconds** (95th percentile ~7 s) after it is timestamped at the site.
+- **Reading the most recent value of one tag** — a single API call returns in **~0.64 seconds** (full request-to-response round-trip).
+- **Reading the most recent value of 100 tags in one batched call** — **~1.5 seconds**.
+- **Latest 10-minute average for every tag of a large site (~75,000 data points)**, in a single batched request — **~3 minutes**.
+- **Latest value of every tag active in the last 5 minutes, across a large site (~75,000 data points)**, in one batched call — **~20 seconds**.
+
+<Note>
+Absolute latency depends on your network path to the endpoint. The read figures above were measured from real users across multiple production environments and include roughly **300 ms of network round-trip**, so your own times will differ. Use these numbers as ballpark figures rather than guarantees; they are drawn from the detailed benchmark tables on the [Query Latency](./query-latency) page.
+</Note>
+
+---
+
+## Performance depends on the size of your query
+
+The single biggest driver of query performance is the **total volume of values a request returns** — the number of data points it addresses multiplied by how many values each has recorded over the requested time window. What matters is the size of the **query**, not the size of your environment: your deployment may span many sites and hundreds of thousands of data points, but a request is only ever as expensive as the slice of that it actually pulls. You control this through how broadly you scope your selectors and time window. As a rough guide by query size:
+
+| Query size | Data points addressed | What to expect |
+|------|-----------|-----------------|
+| **Small** | up to ~2,000 data points | Almost always sub-second to a few seconds. |
+| **Medium** | ~2,000–15,000 data points (e.g. one site or substation) | Batched reads stay fast (a few seconds); this is the sweet spot for the batching patterns described later. |
+| **Large** | 15,000–75,000+ data points in a single request | Measured in seconds-to-minutes, and dominated by **payload transfer** rather than the number of data points. Query strategy matters most here. |
+
+Two other factors shape payload — and therefore latency — on top of the number of data points:
+
+- **Signal density.** A busy site can emit **10–15× more values per tag** in its active period than when quiet (for example, a solar site in daylight versus at night). Payload sizing should always assume peak rates. In our test populations the busiest tags exceeded **1,000 values per tag per day**, but real-world density can be substantially higher depending on how frequently your signals change and how fast the source samples them — size against your own peak rates, not this figure.
+- **Time range and data age.** Recent data (roughly the last 21 days) is served from a hot storage tier and reads fast. Older history is served from a cold tier with a larger first-touch cost. See [Scaling & Best Practices](./scaling-best-practices).
+
+The rule of thumb: **for short and medium time windows, batch aggressively; for long histories, split into smaller requests.** The rest of this section quantifies exactly when and why.
+
+---
+
+## Where to go next
+
+- **[Ingestion Latency](./ingestion-and-freshness)** — how quickly site data becomes available, and why that differs from data freshness.
+- **[Query Latency](./query-latency)** — full benchmark tables for read requests and the query shapes that keep them fast.
+- **[Scaling & Best Practices](./scaling-best-practices)** — batching, parallelization, storage tiers, and recommended patterns per use case and environment size.
+
+For API access and support, contact [contact@nexalis.io](mailto:contact@nexalis.io).

--- a/pages/performance/query-latency.mdx
+++ b/pages/performance/query-latency.mdx
@@ -1,0 +1,140 @@
+---
+title: "Query Latency"
+---
+
+This page reports the **HTTP round-trip time of read requests** to the Nexalis API (`POST /api/v0/exec`) and shows how to shape queries so they stay fast as you scale.
+
+<Note>
+**How to read these numbers.** Each figure is the full round-trip a consumer experiences: network transport in both directions plus the time the Nexalis engine spends executing the request. Measurements were taken from real users across multiple production environments, on standard internet connections with roughly a **300 ms network floor** to the endpoint; your absolute numbers will shift with your own network path, but the *relative* cost of each query shape carries over. All requests use the **optimized query shape** described below.
+</Note>
+
+---
+
+## Latest-value read benchmarks
+
+The table below measures single API calls that fetch the **last 1** or **last 10** values of a set of distinct data points, using the [optimized query shape](#the-optimized-query-shape) described below. Measured on a **large production environment (~490,000 data points)**, 10 repetitions each, against actively-reporting data points.
+
+| Request shape (single API call) | Median | p95 | Min | Max | Server processing |
+|---|---|---|---|---|---|
+| Last **1** value of **1** data point | 644 ms | 668 ms | 627 ms | 673 ms | 283 ms |
+| Last **1** value of **5** data points | 700 ms | 757 ms | 667 ms | 777 ms | 340 ms |
+| Last **1** value of **10** data points | 750 ms | 803 ms | 723 ms | 813 ms | 362 ms |
+| Last **1** value of **100** data points | 1,485 ms | 1,585 ms | 1,399 ms | 1,622 ms | 899 ms |
+| Last **10** values of **1** data point | 749 ms | 821 ms | 636 ms | 826 ms | 309 ms |
+| Last **10** values of **5** data points | 714 ms | 747 ms | 673 ms | 761 ms | 325 ms |
+| Last **10** values of **10** data points | 784 ms | 815 ms | 743 ms | 826 ms | 384 ms |
+| Last **10** values of **100** data points | 1,489 ms | 1,693 ms | 1,397 ms | 1,759 ms | 917 ms |
+
+**What this tells you:**
+
+- **Up to ~10 data points, latency is around 0.6–0.8 s**, dominated by the fixed network round-trip plus a small per-selector cost. Even **100 data points return in ~1.5 s** in a single call.
+- **History depth is nearly free** — fetching the last 10 values costs essentially the same as the last 1.
+- **The main server-side cost is a per-selector directory scan, which scales with the size of your environment, not with how much data you request.** On this ~490,000-data-point environment each selector costs roughly **300 ms**; on a small (~1,500-data-point) environment the same scan is ~6 ms and the identical reads run in **~0.4–0.7 s**.
+- **This is why 100 data points still return in ~1.5 s:** past ~50 data points the query is split into a few narrower selectors (see [the optimized query shape](#the-optimized-query-shape) below), which keeps that per-selector scan cost down.
+- **The difference between round-trip and server processing is network overhead** (~300 ms here). On a low-latency path, reads get proportionally faster.
+- Use the **p95** column, not the median, for timeout and polling-budget planning.
+
+<Note>
+These numbers are a large improvement over earlier measurements (a 100-data-point read dropped from ~3.7 s to ~1.5 s) — the gain comes entirely from following the optimized query shape below.
+</Note>
+
+---
+
+## Long-range read benchmarks
+
+The table above covers small, latest-value reads. Historical pulls behave very differently: latency is set by **payload size**, which grows with the number of tags, the length of the window, and signal density. The figures below were measured on a large production environment (tens of thousands of data points), reading through `exec` FETCH with a single regex selector:
+
+| Query shape | Values returned | Payload | Round-trip |
+|---|---|---|---|
+| 10 tags × 7 days | ~290k | ~8 MB | ~1.9 s |
+| 10 tags × 90 days | ~4.4–4.6M | ~124–132 MB | **44–50 s first read**, ~9–11 s cached |
+| 100 tags × 90 days | ~7–10.4M | ~215–339 MB | ~60–68 s first read (cached not measured) |
+
+**What this tells you:**
+
+- **Long reads are dominated by payload transfer, not selector count.** A 90-day, 100-tag pull moves hundreds of MB — that transfer, not the query itself, sets the time.
+- **The first read of data older than ~21 days pays a one-time cold-tier cost** (44–50 s here), dropping to ~9–11 s on a cached warm repeat. Small recent windows read warm at any age in ~1–2 s. See [Scaling & Best Practices](./scaling-best-practices) for the storage-tier behavior.
+- **Payload — and therefore time — scales with density.** The same 100-tag × 90-day query returned ~215 MB in a quiet-period selection but ~339 MB (and ~10.4M values) in an active-period one. Size for your peak.
+- For long histories, **split large pulls into smaller per-tag or small-batch requests**, and consider parallel chunks — see [Scaling & Best Practices](./scaling-best-practices).
+
+---
+
+## The optimized query shape
+
+Every benchmark on this page follows two rules. Getting either wrong dominates the result.
+
+**Rule 1 — as few selectors as possible, in one API call.** Each selector triggers a fixed directory scan on the server (~300 ms on a ~490,000-data-point environment, far less on a smaller one), so this cost scales with environment size rather than with how much data you ask for. Collapse many data points into a single selector using a regex alternation on `dataPoint`, and send everything in one request rather than one FETCH per tag:
+
+```warpscript
+{
+  'token' 'YOUR_READ_TOKEN'
+  'class' 'nx.value'
+  'labels' { 'dataPoint' '~^(TotW|TotVar|Hz)$' }   // one selector, many data points
+  'start' $now 86400 s -                            // always bound the window
+  'end' $now
+  'count' 1                                         // and cap the result
+} FETCH
+```
+
+Past **~50 data points**, do the opposite of collapsing: **split into a few selectors grouped by `siteName` + `deviceID`.** Each regex is then matched against a much smaller candidate set, which more than pays back the extra directory scans. In benchmarking, 100 data points returned in **~1,440 ms** split by device versus **~1,770 ms** as one flat selector; below ~50, the single-selector form wins.
+
+**Rule 2 — always bound the time window and cap with `count`.** A count read with no `start`/`end` has to walk backwards through storage for every data point until it finds a value, so its cost grows with how *stale* the data is — on a large environment that shape can time out entirely (the identical query returned in under a second when bounded, but failed with an HTTP 502 unbounded). Choose the window generously: it is effectively free for count-bounded reads (1 hour and 7 days both read in ~1.4 s for 100 data points), but too short and quiet tags are **silently omitted** — a 5-minute window returned only 57 of 100 requested tags.
+
+See [Scaling & Best Practices](./scaling-best-practices) for how these rules extend to large historical pulls, and the point at which batching inverts.
+
+---
+
+## Ready-to-use patterns
+
+### Latest value of every tag (real-time polling)
+
+Fetch the most recent value of every tag matching a selector — ideal for a dashboard refreshing every 30 seconds. `'count' 1` returns just the newest value per data point:
+
+```bash
+curl -s -X POST "$NEXALIS_ENDPOINT" \
+  -H "Content-Type: text/plain; charset=UTF-8" \
+  --data "{ 'token' '$NEXALIS_TOKEN' 'class' 'nx.value' 'labels' { 'deviceID' 'YOUR_DEVICE' } 'count' 1 } FETCH NONEMPTY @nexalis/scale"
+```
+
+Set `NEXALIS_ENDPOINT` to `https://yourcompany.app.nexalis.io/api/v0/exec` and `NEXALIS_TOKEN` to your READ token.
+
+To keep the response small and skip tags that haven't changed recently, bound the lookback to a recent window — here the last 5 minutes — while still returning only the latest value per tag (`'count' 1`). `NONEMPTY` drops tags with no value in the window:
+
+```bash
+curl -s -X POST "$NEXALIS_ENDPOINT" \
+  -H "Content-Type: text/plain; charset=UTF-8" \
+  --data "{ 'token' '$NEXALIS_TOKEN' 'class' 'nx.value' 'labels' { 'deviceID' 'YOUR_DEVICE' } 'start' NOW 5 m - 'end' NOW 'count' 1 } FETCH NONEMPTY @nexalis/scale"
+```
+
+For a large site (~75,000 data points), this single batched request returns the latest value of every recently-active tag in roughly **20 seconds**.
+
+### One aggregated value per tag for a whole site
+
+Return a single 10-minute average per data point across an entire large site (~75,000 data points) in one batched request. This is the fastest way to snapshot a full site — around **3 minutes** end to end:
+
+```bash
+curl -s -X POST "$NEXALIS_ENDPOINT" \
+  -H "Content-Type: text/plain; charset=UTF-8" \
+  --data "{ 'token' '$NEXALIS_TOKEN'
+           'start' NOW 600 s / TOLONG 600 s * 600 s -
+           'end'   NOW 600 s / TOLONG 600 s *
+           'bucket_size' 10
+           'labels' { 'deviceID' 'YOUR_DEVICE' } }
+         @nexalis/fetch_trapezoidal_averages"
+```
+
+<Note>
+For **short and medium windows**, batching all tags into one request is fastest. For **long historical ranges** (months of data), do the opposite — split into smaller per-tag or small-batch requests to keep each response manageable and avoid timeouts. The [Scaling & Best Practices](./scaling-best-practices) page explains exactly where the crossover lies.
+</Note>
+
+---
+
+## Key takeaways
+
+- A single-tag latest-value read returns in **~0.64 s**; up to ~10 tags stays under ~0.8 s, and 100 tags in one call in **~1.5 s**.
+- **Group data points into as few selectors as possible and send them in one API call** — but past ~50 data points, split into device-grouped selectors to keep the per-selector directory scan cheap.
+- **Always bound the time window and cap with `count`** — an unbounded read can time out on a large environment. Choose the window generously so quiet tags aren't silently dropped.
+- Plan timeouts against the **p95**, and remember your network path sets the floor.
+- The batching rule holds for short/medium windows; long histories call for the opposite strategy.
+
+See the [Real-Time API reference](../nexalis-cloud/real-time-api/real-time-api) for the full query language, and [Scaling & Best Practices](./scaling-best-practices) for large-scale patterns.

--- a/pages/performance/scaling-best-practices.mdx
+++ b/pages/performance/scaling-best-practices.mdx
@@ -1,0 +1,116 @@
+---
+title: "Scaling & Best Practices"
+---
+
+This page explains how read performance behaves as data volume and time ranges grow, and gives concrete rules for querying efficiently at scale. It draws on measurement campaigns run against large production environments (tens of thousands of data points per site, up to hundreds of megabytes per query).
+
+The single idea underneath everything here: **the cost of a read is driven either by selector resolution or by payload transfer, and which one dominates depends on your time window.** Get that right and everything else follows.
+
+---
+
+## 1. Batch aggressively for short and medium windows
+
+Server-side cost is dominated by **selector resolution**: each selector triggers a directory scan whose cost grows with the size of your environment — from a few milliseconds on a small tenant to a few hundred on a large one — but is independent of how much data the selector returns. So the number of selectors, not the number of tags, drives latency for short and medium windows.
+
+Latency for **1,000 arbitrary data points**, by call shape:
+
+| Call shape | 5-min window | 1-hour window | 24-hour window |
+|---|---|---|---|
+| 1,000 separate FETCH statements (one per data point) | 74.8 s | 74.0 s | 81.3 s |
+| **One FETCH, single 1,000-way regex selector** | **2.5 s** | **2.7 s** | **3.5 s** |
+
+Collapsing 1,000 individual reads into one batched call cuts latency **by more than an order of magnitude**. The rule is to batch many tags into a **single API call with as few selectors as the data allows** — a regex alternation on `dataPoint` (`~^(tagA|tagB|…)$`) or a broad structural prefix for a whole device or site. For large sets, "as few as the data allows" means a handful of device-grouped selectors rather than one giant regex — see the refinement below.
+
+<Note>
+This is the same principle as the [Query Latency](./query-latency) benchmarks: keep the selector count low and send one API call. Two refinements from the latest measurements: past **~50 data points**, splitting into a few selectors grouped by `siteName` + `deviceID` beats one giant regex (each regex then scans a narrower candidate set), and you should **always bound the time window and cap with `count`** — an unbounded read can time out on a large environment. It holds for **short and medium time windows** — see the inversion below for long histories.
+</Note>
+
+---
+
+## 2. …but split long histories into smaller requests
+
+The batching rule **inverts for long time ranges**. At the observed transfer rate (~12 MB/s), a selector's overhead is worth only about **a megabyte of payload**. Once a single data point carries multiple megabytes — for example months of history for a dense tag — transfer time dominates completely and selector overhead becomes irrelevant.
+
+In that regime, per-data-point or small-batch calls cost essentially the same as one giant call, while giving you smaller, more robust responses that are easier to retry and less likely to time out.
+
+| Your time window | Recommended shape |
+|---|---|
+| Seconds to a few days | **One batched request**, many tags in a single regex selector |
+| Weeks to months of history | **Split** into per-tag or small-batch requests; manage per-call payload, not selector count |
+
+This is exactly the guidance behind the two curl patterns on the [Query Latency](./query-latency) page: batch everything for a short window, split for long ranges.
+
+---
+
+## 3. Signal density sets your payload — assume peak rates
+
+Payload size, and therefore latency, is set by how many values your tags actually emit. Because collection is **report-by-exception**, this varies enormously. As an example, here is the density measured on one dense solar site — treat it as an illustration of the *range*, not a target for your own deployment:
+
+| Density metric (example: one solar site) | Value |
+|---|---|
+| Average values per tag per 24 h | ~180 |
+| Median values per tag per 24 h | ~24 (half the tags log 24 values/day or fewer) |
+| p99 values per tag per 24 h | ~1,335 |
+| Daylight vs. night rate (solar site) | **12–15× higher in daylight** |
+| Share of daily volume produced in daylight hours | ~92% |
+
+The swing between busy and quiet periods is the key planning point: a query over a site's active window can return **10× more data** than the same query when it's quiet (for a solar site, daytime versus night). **Always size payloads and timeouts against peak rates**, not averages.
+
+<Note>
+These figures come from one test population and are a **lower bound**, not a ceiling. Tags that change frequently, or are sampled at high frequency at the source, can log many thousands of values per day. Size against your own deployment's peak rates rather than the numbers above.
+</Note>
+
+---
+
+## 4. Parallelize moderately
+
+Splitting a large pull into several simultaneous chunk requests gives a **1.5–2× speedup**, plateauing at around **4 concurrent calls**:
+
+| Concurrency | 1-hour pull | 24-hour pull |
+|---|---|---|
+| 1 (single big call) | 2.8 s | 7.8 s |
+| 4 parallel chunks | 1.6 s | 4.6 s |
+| 8 parallel chunks | 1.4 s | 4.3 s |
+
+The bottleneck is **client bandwidth**, not the server — transfer rate rose from ~12 MB/s (single) to ~19 MB/s (8 parallel) as the client's own link saturated. The platform absorbed 8 concurrent multi-tens-of-MB pulls with no errors and a tight latency spread. A better-connected client (e.g. a cloud VM near the endpoint) would likely scale further.
+
+**Practical rule:** 4–8 parallel chunk requests is the sweet spot. Partition your tags into chunks by structural prefix (device / site) so each chunk is one clean selector.
+
+---
+
+## 5. Storage tiers: recent data is hot, older data is cold
+
+Nexalis serves recent data from a **hot storage tier** (roughly the **last 21 days**) and older history from a cold tier.
+
+- **Hot-tier reads are fast and consistent.** Small recent windows read in a constant 1–2 seconds at any tag count within a site.
+- **Cold-tier reads carry a first-touch cost.** The first read of older history pays a one-time penalty — in benchmarking, a cold read of a 90-day range took **44–50 s**, versus **9–11 s warm** for the same call once cached. Small 7-day windows read warm at any age in a constant ~1–2 s. The full long-range benchmark table is on the [Query Latency](./query-latency#long-range-read-benchmarks) page.
+
+<Note>
+**Recent and historical data are read the same way — through `exec` FETCH (`/api/v0/exec`).** There is no separate endpoint or setting for old data: a query that reaches into the cold tier simply pays the one-time first-touch cost shown above, then reads fast on warm repeats. Just budget for a slower first read when a request touches data older than ~21 days.
+</Note>
+
+Long-range reads work at real scale — over 10 million values (300+ MB) returned in a single call — but this is the regime where you should **manage per-call payload** (rule 2) rather than chase selector count.
+
+---
+
+## Recommended patterns at a glance
+
+| Use case | Recommended pattern |
+|---|---|
+| **Real-time latest values, all tags** (poll every ~30 s) | One batched `FETCH` with `'count' 1` over a broad selector; add `@nexalis/scale`. Sub-second to a few seconds. |
+| **Latest value of recently-active tags** (short lookback) | One batched request, all tags in a single selector, bounded to a recent window with `'count' 1`. |
+| **One aggregated value per tag for a whole site** | One batched macro call with ≥ 10-minute buckets. ~3 minutes for a ~75,000-data-point site. |
+| **Analytical pull, recent data (≤ ~21 days)** | Batch into one selector; use 4–8 parallel chunks for large sites; read from the hot tier. |
+| **Historical data (> 21 days)** | `exec` FETCH only; split into per-tag or small-batch requests; expect a cold first read, fast warm repeats. |
+
+---
+
+## Summary of the rules
+
+1. **Short/medium windows:** batch many tags into one selector, one API call.
+2. **Long histories:** split into smaller requests; payload, not selector count, is the cost.
+3. **Size for peak density**, which can be 10× the average (e.g. daytime on a solar site).
+4. **Parallelize 4–8 ways** for big pulls; the limit is your bandwidth.
+5. **Recent data is hot and fast;** data older than ~21 days is cold (first-touch penalty) and must use `exec` FETCH.
+
+For the underlying query language and examples, see the [Real-Time API reference](../nexalis-cloud/real-time-api/real-time-api) and [Nexalis Macros](../nexalis-cloud/real-time-api/nexalis-macros).


### PR DESCRIPTION
New Performance section under the Nexalis docs covering:
- Overview with headline ingestion/query-latency numbers and query-size framing
- Ingestion latency (and the latency-vs-freshness distinction)
- Query latency benchmarks (latest-value and long-range reads) + optimized query shape
- Scaling & best practices (batching, parallelization, storage tiers)

All figures anonymized from live production measurement campaigns.