### PR TITLE
docs(macros): fix token parameter name and clarify it needs READ access

### DIFF
--- a/pages/nexalis-cloud/real-time-api/nexalis-macros.mdx
+++ b/pages/nexalis-cloud/real-time-api/nexalis-macros.mdx
@@ -95,7 +95,7 @@ Unlike simple arithmetic means, trapezoidal averaging accounts for the time dura
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `read_token` | STRING | Yes | Nexalis API read token with fetch permissions |
+| `token` | STRING | Yes | Nexalis API token with READ access privileges |
 | `start` | STRING or LONG | Yes | Start timestamp (ISO8601 string or microseconds) |
 | `end` | STRING or LONG | Yes | End timestamp (ISO8601 string or microseconds) |
 | `bucket_size` | LONG | Yes | Bucket width in minutes |
@@ -162,7 +162,7 @@ Use this macro when you want to:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `token` | STRING | Yes | Nexalis API read token with fetch permissions |
+| `token` | STRING | Yes | Nexalis API token with READ access privileges |
 | `start` | STRING or LONG | Yes | Start timestamp (ISO8601 string or microseconds) |
 | `end` | STRING or LONG | Yes | End timestamp (ISO8601 string or microseconds) |
 | `bucket_size` | LONG | Yes | Bucket width in minutes |


### PR DESCRIPTION
## Problem

The parameter table for `@nexalis/fetch_trapezoidal_averages` documents the token key as `read_token`. The macro does not accept that name:

```
ASSERTMSG failed 'Missing parameter: token'
```

Both `@nexalis/fetch_trapezoidal_averages` and `@nexalis/fetch_bucketized` require `token`.

This is easy to miss because the **code examples on the same page are already correct** — they use `'token' $read_token`. So copying the example works, while copying the parameter table fails. Only the table was wrong.

## Also: "read_token" is misleading naming

Warp10 tokens are single-verb — a token is a READ token or a WRITE token, issued separately, with no combined form. Naming the parameter `read_token` reads as though it were a distinct *kind* of credential rather than a parameter that expects a token with read access.

Both sibling macros now describe the same parameter identically:

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `token` | STRING | Yes | Nexalis API token with READ access privileges |

## Verification

Tested against a live endpoint. `token` succeeds on both macros; `read_token` raises the assert above on both.

## Scope

Two lines in one file. No behaviour, no examples, and no other page touched.

---

Found while building the Power BI connector, where following the table produced a failing query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)